### PR TITLE
fix: prevent search from clearing on every keystroke in Standings

### DIFF
--- a/client/src/pages/Tournament/Standings/Standings.tsx
+++ b/client/src/pages/Tournament/Standings/Standings.tsx
@@ -54,7 +54,8 @@ export const Standings = () => {
       },
       { replace: true },
     );
-  }, [division, setSearchParams]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [division]);
 
   const standings = useMemo(() => {
     const divisionData = divisions.find(d => d.division === division);

--- a/client/src/pages/Tournament/Standings/Standings.tsx
+++ b/client/src/pages/Tournament/Standings/Standings.tsx
@@ -54,6 +54,7 @@ export const Standings = () => {
       },
       { replace: true },
     );
+    // setSearchParams is not referentially stable in React Router v6 (it changes when location changes); excluding it prevents this effect from re-running on each search-param update.
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [division]);
 


### PR DESCRIPTION
setSearchParams is not referentially stable in React Router v6 — it changes whenever location changes. Including it in the useEffect dependency array caused the effect to re-run on every search keystroke, deleting the search param immediately after it was set.